### PR TITLE
Add ability to opt-out window resizing in IE

### DIFF
--- a/cpp/iedriver/CommandHandlers/NewSessionCommandHandler.h
+++ b/cpp/iedriver/CommandHandlers/NewSessionCommandHandler.h
@@ -76,6 +76,8 @@ class NewSessionCommandHandler : public IECommandHandler {
       Json::Value enable_element_cache_cleanup = this->GetCapability(it->second, ENABLE_ELEMENT_CACHE_CLEANUP_CAPABILITY, Json::booleanValue, true);
       mutable_executor.set_enable_element_cache_cleanup(enable_element_cache_cleanup.asBool());
       Json::Value enable_persistent_hover = this->GetCapability(it->second, ENABLE_PERSISTENT_HOVER_CAPABILITY, Json::booleanValue, true);
+      Json::Value resize_when_taking_screenshot = this->GetCapability(it->second, RESIZE_WHEN_TAKING_SCREENSHOT_CAPABILITY, Json::booleanValue, true);
+      mutable_executor.set_resize_when_taking_screenshot(resize_when_taking_screenshot.asBool());
       if (require_window_focus.asBool() || !enable_native_events.asBool()) {
         // Setting "require_window_focus" implies SendInput() API, and does not therefore require
         // persistent hover. Likewise, not using native events requires no persistent hover either.

--- a/cpp/iedriver/IECommandExecutor.cpp
+++ b/cpp/iedriver/IECommandExecutor.cpp
@@ -91,7 +91,7 @@ LRESULT IECommandExecutor::OnCreate(UINT uMsg,
                                     LPARAM lParam,
                                     BOOL& bHandled) {
   LOG(TRACE) << "Entering IECommandExecutor::OnCreate";
-  
+
   CREATESTRUCT* create = reinterpret_cast<CREATESTRUCT*>(lParam);
   IECommandExecutorThreadContext* context = reinterpret_cast<IECommandExecutorThreadContext*>(create->lpCreateParams);
   this->port_ = context->port;
@@ -104,7 +104,7 @@ LRESULT IECommandExecutor::OnCreate(UINT uMsg,
   status = ::UuidToString(&guid, &guid_string);
 
   // RPC_WSTR is currently typedef'd in RpcDce.h (pulled in by rpc.h)
-  // as unsigned short*. It needs to be typedef'd as wchar_t* 
+  // as unsigned short*. It needs to be typedef'd as wchar_t*
   wchar_t* cast_guid_string = reinterpret_cast<wchar_t*>(guid_string);
   this->SetWindowText(cast_guid_string);
 
@@ -126,6 +126,7 @@ LRESULT IECommandExecutor::OnCreate(UINT uMsg,
   this->page_load_timeout_ = -1;
   this->is_waiting_ = false;
   this->page_load_strategy_ = "normal";
+  this->resize_when_taking_screenshot_ = true;
 
   this->input_manager_ = new InputManager();
   this->input_manager_->Initialize(&this->managed_elements_);
@@ -225,7 +226,7 @@ LRESULT IECommandExecutor::OnWait(UINT uMsg,
       if (this->is_waiting_) {
         // If we are still waiting, we need to wait a bit then post a message to
         // ourselves to run the wait again. However, we can't wait using Sleep()
-        // on this thread. This call happens in a message loop, and we would be 
+        // on this thread. This call happens in a message loop, and we would be
         // unable to process the COM events in the browser if we put this thread
         // to sleep.
         unsigned int thread_id = 0;
@@ -474,7 +475,7 @@ void IECommandExecutor::DispatchCommand() {
   LOG(TRACE) << "Entering IECommandExecutor::DispatchCommand";
 
   Response response(this->session_id_);
-  CommandHandlerMap::const_iterator found_iterator = 
+  CommandHandlerMap::const_iterator found_iterator =
       this->command_handlers_.find(this->current_command_.command_type());
 
   if (found_iterator == this->command_handlers_.end()) {
@@ -605,7 +606,7 @@ int IECommandExecutor::GetManagedBrowser(const std::string& browser_id,
     return ENOSUCHWINDOW;
   }
 
-  BrowserMap::const_iterator found_iterator = 
+  BrowserMap::const_iterator found_iterator =
       this->managed_browsers_.find(browser_id);
   if (found_iterator == this->managed_browsers_.end()) {
     LOG(WARN) << "Unable to find managed browser with id " << browser_id;
@@ -656,12 +657,12 @@ int IECommandExecutor::CreateNewBrowser(std::string* error_message) {
   process_window_info.pBrowser = NULL;
   bool attached = this->factory_->AttachToBrowser(&process_window_info,
                                                   error_message);
-  if (!attached) { 
+  if (!attached) {
     LOG(WARN) << "Unable to attach to browser COM object";
     this->is_waiting_ = false;
     return ENOSUCHDRIVER;
   }
-  // Set persistent hover functionality in the interactions implementation. 
+  // Set persistent hover functionality in the interactions implementation.
   setEnablePersistentHover(this->enable_persistent_hover_);
   LOG(INFO) << "Persistent hovering set to: " << this->enable_persistent_hover_;
   if (!this->enable_persistent_hover_) {

--- a/cpp/iedriver/IECommandExecutor.h
+++ b/cpp/iedriver/IECommandExecutor.h
@@ -92,8 +92,8 @@ class IECommandExecutor : public CWindowImpl<IECommandExecutor> {
   static unsigned int WINAPI ThreadProc(LPVOID lpParameter);
   static unsigned int WINAPI WaitThreadProc(LPVOID lpParameter);
 
-  std::string current_browser_id(void) const { 
-    return this->current_browser_id_; 
+  std::string current_browser_id(void) const {
+    return this->current_browser_id_;
   }
   void set_current_browser_id(const std::string& browser_id) {
     this->current_browser_id_ = browser_id;
@@ -125,11 +125,11 @@ class IECommandExecutor : public CWindowImpl<IECommandExecutor> {
                      const std::string& criteria,
                      Json::Value* found_elements) const;
 
-  int implicit_wait_timeout(void) const { 
-    return this->implicit_wait_timeout_; 
+  int implicit_wait_timeout(void) const {
+    return this->implicit_wait_timeout_;
   }
-  void set_implicit_wait_timeout(const int timeout) { 
-    this->implicit_wait_timeout_ = timeout; 
+  void set_implicit_wait_timeout(const int timeout) {
+    this->implicit_wait_timeout_ = timeout;
   }
 
   int async_script_timeout(void) const { return this->async_script_timeout_;  }
@@ -144,12 +144,12 @@ class IECommandExecutor : public CWindowImpl<IECommandExecutor> {
 
   bool is_valid(void) const { return this->is_valid_; }
   void set_is_valid(const bool session_is_valid) {
-    this->is_valid_ = session_is_valid; 
+    this->is_valid_ = session_is_valid;
   }
 
   bool is_quitting(void) const { return this->is_quitting_; }
   void set_is_quitting(const bool session_is_quitting) {
-    this->is_quitting_ = session_is_quitting; 
+    this->is_quitting_ = session_is_quitting;
   }
 
   bool enable_element_cache_cleanup(void) const {
@@ -185,6 +185,14 @@ class IECommandExecutor : public CWindowImpl<IECommandExecutor> {
   }
   void set_page_load_strategy(const std::string& page_load_strategy) {
     this->page_load_strategy_ = page_load_strategy;
+  }
+
+  bool resize_when_taking_screenshot(void) const {
+    return this->resize_when_taking_screenshot_;
+  }
+
+  void set_resize_when_taking_screenshot(const bool resize_when_taking_screenshot) {
+    this->resize_when_taking_screenshot_ = resize_when_taking_screenshot;
   }
 
   ElementFinder element_finder(void) const { return this->element_finder_; }
@@ -238,6 +246,7 @@ class IECommandExecutor : public CWindowImpl<IECommandExecutor> {
   std::string unexpected_alert_behavior_;
   bool validate_cookie_document_type_;
   std::string page_load_strategy_;
+  bool resize_when_taking_screenshot_;
 
   Command current_command_;
   std::string serialized_response_;

--- a/cpp/iedriver/IECommandHandler.h
+++ b/cpp/iedriver/IECommandHandler.h
@@ -51,6 +51,7 @@
 #define ENSURE_CLEAN_SESSION_CAPABILITY "ie.ensureCleanSession"
 #define FORCE_SHELL_WINDOWS_API_CAPABILITY "ie.forceShellWindowsApi"
 #define VALIDATE_COOKIE_DOCUMENT_TYPE_CAPABILITY "ie.validateCookieDocumentType"
+#define RESIZE_WHEN_TAKING_SCREENSHOT_CAPABILITY "ie.resizeWhenTakingScreenshot"
 
 using namespace std;
 


### PR DESCRIPTION
Adds additional capability 'ie.resizeWhenTakingScreenshot' which
allows to disable window resizing and capture only viewport. Default
behavior have not changed.
